### PR TITLE
add licence

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,8 @@ are available as
 [a pdf](https://github.com/ots22/rackpropagator/tree/master/talk/slides-lambda-days.pdf)
 or as
 [a Racket slideshow program](https://github.com/ots22/rackpropagator/tree/master/talk/slides-lambda-days.rkt).
+
+# License
+
+We follow the lead of the main Racket license:
+This code is distributed under the MIT license and the Apache version 2.0 license, at your option. 


### PR DESCRIPTION
I'm watching your lambda days presentation and I noticed that while you had created this package you had not made it available. 
Would you be interested in putting it on the Racket package catalog so others can use it. 

This PR adds a simple licence declaration that is compatible with Racket.
I copied from the float/sci package https://github.com/soegaard/sci/blob/master/README.md

If you want to discuss I am a fellow Londoner and you can get me on the Racket discord https://discord.gg/6Zq8sH5 as Stephen or spdegabrielle on the racket discourse  https://racket.discourse.group/
best wishes and happy new year